### PR TITLE
90% - Bump app-logger-angular to 2.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,9 @@
+## 1.2.0 (2016-02-19)
+
+Features:
+
+  - Bump app-logger-angular to ~2.0.
+
+## 1.x.x
+
+Initial version

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "echo-angular",
-  "version": "1.1.0",
+  "version": "2.0.0",
   "main": "./js/echo.services.js",
   "description": "Client for Talis Echo",
   "repository": {
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "angular": "*",
-    "app-logger-angular": "1.1.0",
+    "app-logger-angular": "~2.0",
     "lodash": "~2.4.1"
   },
   "ignore": [

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "echo-angular",
-  "version": "2.0.0",
+  "version": "1.2.0",
   "main": "./js/echo.services.js",
   "description": "Client for Talis Echo",
   "repository": {


### PR DESCRIPTION
TN depends on echo-angular-service (fixed version) which depended on app-logger-angular (fixed version).  Now that a new version of app-logger-angular has been created we can't update TN to use a later version with this module depending on a specific version of app-logger-angular. 

This PR changes the dependency to ~2.0 (any 2.x version) of app-logger-angular to remove the tight coupling in the future and allow backward-compatible versions to be used more readily without needing to update echo-angular-service every time