### PR TITLE
90% - Change app-logger-angular to 2.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.2.1 (2016-02-24)
+
+Bug fixes:
+
+  - Change version of app-logger-angular to 2.x as ~2.0 wasn't allowing 2.1 onwards.
+
 ## 1.2.0 (2016-02-19)
 
 Features:

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "echo-angular",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "main": "./js/echo.services.js",
   "description": "Client for Talis Echo",
   "repository": {
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "angular": "*",
-    "app-logger-angular": "~2.0",
+    "app-logger-angular": "2.x",
     "lodash": "~2.4.1"
   },
   "ignore": [


### PR DESCRIPTION
The dependency on app-logger-angular at ~2.0 should have theoretically allowed 2.x.x to be pulled in but wasn't allowing 2.1.x.  Changed the dependency to use 2.x instead.